### PR TITLE
Show colors of the traces in the list widget

### DIFF
--- a/GUIConfig.py.example
+++ b/GUIConfig.py.example
@@ -6,8 +6,9 @@ pg.setConfigOption('background', 'k')
 pg.setConfigOption('foreground', 'y')
 
 class traceListConfig():
-    def __init__(self, background_color = 'white'):
+    def __init__(self, background_color = 'white', use_trace_color = False):
         self.background_color = background_color
+        self.use_trace_color = use_trace_color
 
 class graphConfig():
     def __init__(self, name, ylim=[0,1], isScrolling=False, max_datasets = 20,

--- a/GraphWidgetPyQtGraph.py
+++ b/GraphWidgetPyQtGraph.py
@@ -95,7 +95,7 @@ class Graph_PyQtGraph(QtGui.QWidget):
         if self.grid_on:
             self.pw.showGrid(x=True, y=True)
         self.artists[ident] = artistParameters(line, dataset, index, True)
-        self.tracelist.addTrace(ident)
+        self.tracelist.addTrace(ident, new_color)
 
     def remove_artist(self, ident):
         try:


### PR DESCRIPTION
Addresses #16. For each trace, the text in the list widget shows "trace_name - color". There is also an option  (use_trace_color, default False) in updated GUIConfig to show the text in the color of the trace.

The corresponding texts will update when the colors of the traces are changed.