### PR TITLE
add remove trace menuitems to TraceListWidget

### DIFF
--- a/GraphWidgetPyQtGraph.py
+++ b/GraphWidgetPyQtGraph.py
@@ -130,12 +130,21 @@ class Graph_PyQtGraph(QtGui.QWidget):
                         params.artist.setData(x,y)
                 except: pass
 
+    def _check_artist_exist(self, ident):
+        if ident in self.artists.keys():
+            counter = 1
+            while ident + str(counter) in self.artists.keys():
+                counter += 1
+            ident += str(counter)
+        return ident
+
     def add_artist(self, ident, dataset, index, no_points = False):
         '''
         no_points is an override parameter to the global show_points setting.
         It is to allow data fits to be plotted without points
         '''
         new_color = self.colorChooser.next()
+        ident = self._check_artist_exist(ident)
         if self.show_points and not no_points:
             line = self.pw.plot([], [], symbol='o', symbolBrush=self.getItemColor(new_color),
                                 name=ident, pen = self.getItemColor(new_color), connect=self.scatter_plot)

--- a/TraceListWidget.py
+++ b/TraceListWidget.py
@@ -59,6 +59,7 @@ class TraceList(QtGui.QListWidget):
         if (item == None): 
             dataaddAction = menu.addAction('Add Data Set')
             spectrumaddAction = menu.addAction('Add Predicted Spectrum')
+            removeallAction = menu.addAction('Remove All Traces')
 
             action = menu.exec_(self.mapToGlobal(pos))
             if action == dataaddAction:
@@ -71,7 +72,10 @@ class TraceList(QtGui.QListWidget):
                 self.windows.append(ps)
                 ps.show()
 
-
+            if action == removeallAction:
+                for kk in reversed(range(self.count())):
+                    ident = str(self.item(kk).text())
+                    self.parent.remove_artist(ident)
 
         else:
             ident = str(item.text())
@@ -85,6 +89,7 @@ class TraceList(QtGui.QListWidget):
             cyanAction = selectColorMenu.addAction("Cyan")
             magentaAction = selectColorMenu.addAction("Magenta")
             whiteAction = selectColorMenu.addAction("White")
+            removeAction = menu.addAction('Remove')
             colorActionDict = {redAction:"r", greenAction:"g", yellowAction:"y", cyanAction:"c", magentaAction:"m", whiteAction:"w"}
 
             action = menu.exec_(self.mapToGlobal(pos))
@@ -124,3 +129,6 @@ class TraceList(QtGui.QListWidget):
                 else:
                     self.parent.artists[ident].artist.setData(pen = new_color)
                     self.changeTraceListColor(ident, new_color)
+
+            if action == removeAction:
+                self.parent.remove_artist(ident)


### PR DESCRIPTION
Addresses #21.

Changes:
- New traces with identical names with existing traces will have a trailing number in the end of the trace name. This prevents adding two same named traces to a graph and overwrite the former trace in self.artists in GraphWidgetPyQtGraph.py.
- A menuitem to remove all traces from graph
- A menuitem to remove selected trace from graph

I only tested it with data sets and it is working on my computer. Let me know if it does not work.